### PR TITLE
Implement fee refunds for successful `payout_stakers` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add dynamic fee recycling rate calculation based on treasury balance
+- Refund fees for successful `payout_stakers` calls
 - Runtime API to access parameters used for energy generation and exchange rate calculations
 
 ### Changed

--- a/pallets/energy-generation/src/pallet/impls.rs
+++ b/pallets/energy-generation/src/pallet/impls.rs
@@ -378,7 +378,9 @@ impl<T: Config> Pallet<T> {
 
         T::Reward::on_unbalanced(total_imbalance);
         debug_assert!(cooperator_payout_count <= T::MaxCooperatorRewardedPerValidator::get());
-        Ok(Some(T::ThisWeightInfo::payout_stakers_alive_staked(cooperator_payout_count)).into())
+
+        let weight = T::ThisWeightInfo::payout_stakers_alive_staked(cooperator_payout_count);
+        Ok((Some(weight), Pays::No).into())
     }
 
     /// Actually make a payment to a staker. This uses the currency's reward function

--- a/pallets/energy-generation/src/pallet/mod.rs
+++ b/pallets/energy-generation/src/pallet/mod.rs
@@ -1531,6 +1531,7 @@ pub mod pallet {
         /// The origin of this call must be _Signed_. Any account can call this function, even if
         /// it is not one of the stakers.
         ///
+        /// Transaction fees will be waived if the call is successful.
         /// ## Complexity
         /// - At most O(MaxCooperatorRewardedPerValidator).
         #[pallet::call_index(19)]

--- a/pallets/energy-generation/src/tests.rs
+++ b/pallets/energy-generation/src/tests.rs
@@ -4573,6 +4573,19 @@ fn payout_stakers_handles_weight_refund() {
 }
 
 #[test]
+fn payout_stakers_first_payout_free_works() {
+    ExtBuilder::default().build_and_execute(|| {
+        start_active_era(1);
+
+        let res = PowerPlant::payout_stakers(RuntimeOrigin::signed(1), 11, 0);
+        assert_eq!(res.unwrap().pays_fee, Pays::No);
+
+        let res = PowerPlant::payout_stakers(RuntimeOrigin::signed(1), 11, 0);
+        assert_eq!(res.unwrap_err().post_info.pays_fee, Pays::Yes);
+    });
+}
+
+#[test]
 fn bond_during_era_correctly_populates_claimed_rewards() {
     ExtBuilder::default().has_stakers(false).build_and_execute(|| {
         // Era = None


### PR DESCRIPTION
<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->
